### PR TITLE
Fixed tab title type warning

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 const Tab = ({ title, id, children }) => (<div id={`tab-${id || String(title).replace(/\s/g, '-')}`}>{children}</div>);
 
 Tab.propTypes = {
-  title: PropTypes.string.isRequired,
   id: PropTypes.string,
+  title: PropTypes.oneOfType([
+    PropTypes.string, 
+    PropTypes.element
+  ]).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.element),
     PropTypes.arrayOf(PropTypes.node),


### PR DESCRIPTION
We're passing LocaleFormattedMessage to show translated tab titles, which isn't string.